### PR TITLE
Rewrite API

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -1,3 +1,0 @@
-disallowed-methods = [
-    { path = "core::mem::forget", reason = "mem::forget is sketchy around unsafe code, use ManuallyDrop instead" }
-]

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,3 @@
+disallowed-methods = [
+    { path = "core::mem::forget", reason = "mem::forget is sketchy around unsafe code, use ManuallyDrop instead" }
+]

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -6,7 +6,7 @@ use sptr::Strict;
 /// be implemented on `Copy` types like `usize`, `u64`, or `u128`. Note that the `Self` type here
 /// serves as the main interchange format between the `Backend` and [`StuffedPtr`](`crate::StuffedPtr`)
 /// but *not* the actual underlying storage, which always contains a pointer to keep provenance
-/// (for example `(*mut T, u32)` on 32 bit for `u64`). This implies that `Self` *should* have the same
+/// (for example `(*mut (), u32)` on 32 bit for `u64`). This implies that `Self` *should* have the same
 /// size as `Backend::Stored`.
 ///
 /// This trait is just exposed for convenience and flexibility, you are usually not expected to implement
@@ -16,7 +16,7 @@ use sptr::Strict;
 /// # Safety
 /// Implementers of this trait *must* keep provenance of pointers, so if a valid pointer address+provenance
 /// combination is set in `set_ptr`, `get_ptr` *must* return the exact same values and provenance.
-pub unsafe trait Backend<T> {
+pub unsafe trait Backend {
     /// The underlying type where the data is stored. Often a tuple of a pointer (for the provenance)
     /// and some integers to fill up the bytes.
     type Stored: Copy;
@@ -25,11 +25,11 @@ pub unsafe trait Backend<T> {
     /// is able to use the full bytes to pack in the pointer address, the full address is returned
     /// in the second tuple field, as the integer. The provenance of the pointer is returned as
     /// the first tuple field, but its address should be ignored and may be invalid.
-    fn get_ptr(s: Self::Stored) -> (*mut T, Self);
+    fn get_ptr(s: Self::Stored) -> (*mut (), Self);
 
     /// Set a new pointer address. The provenance of the new pointer is transferred in the first argument,
     /// and the address in the second. See [`Backend::get_ptr`] for more details on the separation.
-    fn set_ptr(provenance: *mut T, addr: Self) -> Self::Stored;
+    fn set_ptr(provenance: *mut (), addr: Self) -> Self::Stored;
 
     /// Get the integer value from the backend. Note that this *must not* be used to create a pointer,
     /// for that use [`Backend::get_ptr`] to keep the provenance.
@@ -49,19 +49,19 @@ mod backend_size_asserts {
     }
 
     #[cfg(not(target_pointer_width = "16"))]
-    const _: () = assert_same_size::<u128, <u128 as Backend<()>>::Stored>();
-    const _: () = assert_same_size::<u64, <u64 as Backend<()>>::Stored>();
-    const _: () = assert_same_size::<usize, <usize as Backend<()>>::Stored>();
+    const _: () = assert_same_size::<u128, <u128 as Backend>::Stored>();
+    const _: () = assert_same_size::<u64, <u64 as Backend>::Stored>();
+    const _: () = assert_same_size::<usize, <usize as Backend>::Stored>();
 }
 
-unsafe impl<T> Backend<T> for usize {
-    type Stored = *mut T;
+unsafe impl Backend for usize {
+    type Stored = *mut ();
 
-    fn get_ptr(s: Self::Stored) -> (*mut T, Self) {
+    fn get_ptr(s: Self::Stored) -> (*mut (), Self) {
         (s, Strict::addr(s))
     }
 
-    fn set_ptr(provenance: *mut T, addr: Self) -> Self::Stored {
+    fn set_ptr(provenance: *mut (), addr: Self) -> Self::Stored {
         Strict::with_addr(provenance, addr)
     }
 
@@ -72,14 +72,14 @@ unsafe impl<T> Backend<T> for usize {
 
 #[cfg(target_pointer_width = "64")]
 /// on 64 bit, we can just treat u64/usize interchangeably, because uintptr_t == size_t in Rust
-unsafe impl<T> Backend<T> for u64 {
-    type Stored = *mut T;
+unsafe impl Backend for u64 {
+    type Stored = *mut ();
 
-    fn get_ptr(s: Self::Stored) -> (*mut T, Self) {
+    fn get_ptr(s: Self::Stored) -> (*mut (), Self) {
         (s, Strict::addr(s) as u64)
     }
 
-    fn set_ptr(provenance: *mut T, addr: Self) -> Self::Stored {
+    fn set_ptr(provenance: *mut (), addr: Self) -> Self::Stored {
         Strict::with_addr(provenance, addr as usize)
     }
 
@@ -89,17 +89,17 @@ unsafe impl<T> Backend<T> for u64 {
 }
 
 macro_rules! impl_backend_2_tuple {
-    (impl for $ty:ty { (*mut T, $int:ident), $num:expr }) => {
-        unsafe impl<T> Backend<T> for $ty {
+    (impl for $ty:ty { (*mut (), $int:ident), $num:expr }) => {
+        unsafe impl Backend for $ty {
             // this one keeps the MSB in the pointer address, and the LSB in the integer
 
-            type Stored = (*mut T, $int);
+            type Stored = (*mut (), $int);
 
-            fn get_ptr(s: Self::Stored) -> (*mut T, Self) {
+            fn get_ptr(s: Self::Stored) -> (*mut (), Self) {
                 (s.0, Self::get_int(s))
             }
 
-            fn set_ptr(provenance: *mut T, addr: Self) -> Self::Stored {
+            fn set_ptr(provenance: *mut (), addr: Self) -> Self::Stored {
                 let ptr_addr = (addr >> $num) as usize;
                 let int_addr = addr as $int; // truncate it
                 (Strict::with_addr(provenance, ptr_addr), int_addr)
@@ -116,17 +116,17 @@ macro_rules! impl_backend_2_tuple {
 /// num1 is ptr-sized, num2 is 2*ptr sized
 #[cfg_attr(target_pointer_width = "64", allow(unused))] // not required on 64 bit
 macro_rules! impl_backend_3_tuple {
-    (impl for $ty:ty { (*mut T, $int1:ident, $int2:ident), $num1:expr, $num2:expr }) => {
-        unsafe impl<T> Backend<T> for $ty {
+    (impl for $ty:ty { (*mut (), $int1:ident, $int2:ident), $num1:expr, $num2:expr }) => {
+        unsafe impl Backend for $ty {
             // this one keeps the MSB in the pointer address, ISB in int1 and the LSB in the int2
 
-            type Stored = (*mut T, $int1, $int2);
+            type Stored = (*mut (), $int1, $int2);
 
-            fn get_ptr(s: Self::Stored) -> (*mut T, Self) {
+            fn get_ptr(s: Self::Stored) -> (*mut (), Self) {
                 (s.0, Self::get_int(s))
             }
 
-            fn set_ptr(provenance: *mut T, addr: Self) -> Self::Stored {
+            fn set_ptr(provenance: *mut (), addr: Self) -> Self::Stored {
                 let ptr_addr = (addr >> ($num1 + $num2)) as usize;
                 let num1_addr = (addr >> $num2) as $int1; // truncate it
                 let num2_addr = addr as $int2; // truncate it
@@ -148,15 +148,15 @@ macro_rules! impl_backend_3_tuple {
 }
 
 #[cfg(target_pointer_width = "64")]
-impl_backend_2_tuple!(impl for u128 { (*mut T, u64), 64 });
+impl_backend_2_tuple!(impl for u128 { (*mut (), u64), 64 });
 
 #[cfg(target_pointer_width = "32")]
-impl_backend_2_tuple!(impl for u64 { (*mut T, u32), 32 });
+impl_backend_2_tuple!(impl for u64 { (*mut (), u32), 32 });
 
 #[cfg(target_pointer_width = "32")]
-impl_backend_3_tuple!(impl for u128 { (*mut T, u32, u64), 32, 64 });
+impl_backend_3_tuple!(impl for u128 { (*mut (), u32, u64), 32, 64 });
 
 #[cfg(target_pointer_width = "16")]
-impl_backend_3_tuple!(impl for u64 { (*mut T, u16, u32), 16, 32 });
+impl_backend_3_tuple!(impl for u64 { (*mut (), u16, u32), 16, 32 });
 
 // no 128 on 16 bit for now

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -54,6 +54,7 @@ mod backend_size_asserts {
     const _: () = assert_same_size::<usize, <usize as Backend>::Stored>();
 }
 
+// SAFETY: We are careful around provenance
 unsafe impl Backend for usize {
     type Stored = *mut ();
 
@@ -72,6 +73,7 @@ unsafe impl Backend for usize {
 
 #[cfg(target_pointer_width = "64")]
 /// on 64 bit, we can just treat u64/usize interchangeably, because uintptr_t == size_t in Rust
+// SAFETY: We are careful around provenance
 unsafe impl Backend for u64 {
     type Stored = *mut ();
 
@@ -90,6 +92,7 @@ unsafe impl Backend for u64 {
 
 macro_rules! impl_backend_2_tuple {
     (impl for $ty:ty { (*mut (), $int:ident), $num:expr }) => {
+        // SAFETY: We are careful around provenance
         unsafe impl Backend for $ty {
             // this one keeps the MSB in the pointer address, and the LSB in the integer
 
@@ -117,6 +120,7 @@ macro_rules! impl_backend_2_tuple {
 #[cfg_attr(target_pointer_width = "64", allow(unused))] // not required on 64 bit
 macro_rules! impl_backend_3_tuple {
     (impl for $ty:ty { (*mut (), $int1:ident, $int2:ident), $num1:expr, $num2:expr }) => {
+        // SAFETY: We are careful around provenance
         unsafe impl Backend for $ty {
             // this one keeps the MSB in the pointer address, ISB in int1 and the LSB in the int2
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,10 +2,6 @@
 #![warn(rust_2018_idioms)]
 #![warn(missing_docs)]
 #![deny(clippy::undocumented_unsafe_blocks)]
-// deny the fuzzy provenance casts during tests
-// this makes `cargo test` require nightly but i don't care
-#![cfg_attr(test, feature(strict_provenance))]
-#![cfg_attr(test, deny(fuzzy_provenance_casts))]
 
 //! A crate for stuffing things into a pointer.
 //!
@@ -283,7 +279,7 @@ mod either {
 
 #[cfg(test)]
 mod tests {
-    #![allow(non_snake_case)]
+    #![allow(non_snake_case, clippy::undocumented_unsafe_blocks)]
 
     use std::{boxed::Box, format, println};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,7 +42,7 @@
 //! // implementation detail of NaN boxing, the sign bit of an f64
 //! const SIGN_BIT: u64 = 0x8000000000000000;
 //!
-//! unsafe impl StuffingStrategy<u64> for NanBoxStrategy {
+//! impl StuffingStrategy<u64> for NanBoxStrategy {
 //!     type Other = f64;
 //!
 //!     fn stuff_other(inner: Self::Other) -> u64 {

--- a/src/strategy.rs
+++ b/src/strategy.rs
@@ -10,15 +10,7 @@ use crate::{Backend, Unstuffed};
 /// if possible.
 ///
 /// The generic parameter `B` stands for the [`Backend`](`crate::Backend`) used by the strategy.
-///
-/// # Safety
-///
-/// If [`StuffingStrategy::is_other`] returns true for a value, then
-/// [`StuffingStrategy::extract_other`] *must* return a valid `Other` for that same value.
-///
-/// For [`StuffingStrategy::stuff_ptr`] and [`StuffingStrategy::extract_ptr`],
-/// `ptr == extract_ptr(stuff_ptr(ptr))` *must* hold true.
-pub unsafe trait StuffingStrategy<B> {
+pub trait StuffingStrategy<B> {
     /// The type of the other.
     type Other: Copy;
 
@@ -40,7 +32,7 @@ pub unsafe trait StuffingStrategy<B> {
     fn stuff_ptr(addr: usize) -> B;
 }
 
-unsafe impl<B> StuffingStrategy<B> for ()
+impl<B> StuffingStrategy<B> for ()
 where
     B: Backend + Default + TryInto<usize>,
     usize: TryInto<B>,
@@ -75,7 +67,7 @@ pub(crate) mod test_strategies {
     macro_rules! impl_usize_max_zst {
         ($ty:ident) => {
             // this one lives in usize::MAX
-            unsafe impl StuffingStrategy<usize> for $ty {
+            impl StuffingStrategy<usize> for $ty {
                 type Other = Self;
 
                 #[allow(clippy::forget_copy)]
@@ -96,7 +88,7 @@ pub(crate) mod test_strategies {
                 }
             }
 
-            unsafe impl StuffingStrategy<u64> for $ty {
+            impl StuffingStrategy<u64> for $ty {
                 type Other = Self;
 
                 #[allow(clippy::forget_copy)]
@@ -117,7 +109,7 @@ pub(crate) mod test_strategies {
                 }
             }
 
-            unsafe impl StuffingStrategy<u128> for $ty {
+            impl StuffingStrategy<u128> for $ty {
                 type Other = Self;
 
                 #[allow(clippy::forget_copy)]

--- a/src/tag.rs
+++ b/src/tag.rs
@@ -6,14 +6,14 @@ use sptr::Strict;
 
 use crate::Backend;
 
-pub struct TaggedPtr<T, S, B = usize>(B::Stored, PhantomData<S>)
+pub struct TaggedPtr<T, S, B = usize>(B::Stored, PhantomData<(S, *mut T)>)
 where
-    B: Backend<T>;
+    B: Backend;
 
 impl<T, S, B> TaggedPtr<T, S, B>
 where
     S: TaggingStrategy<B>,
-    B: Backend<T>,
+    B: Backend,
 {
     pub fn new(ptr: *mut T, tag: S::Tag) -> Self {
         let addr = Strict::addr(ptr);
@@ -44,14 +44,14 @@ where
 
 impl<T, S, B> Clone for TaggedPtr<T, S, B>
 where
-    B: Backend<T>,
+    B: Backend,
 {
     fn clone(&self) -> Self {
         TaggedPtr(self.0, self.1)
     }
 }
 
-impl<T, S, B> Copy for TaggedPtr<T, S, B> where B: Backend<T> {}
+impl<T, S, B> Copy for TaggedPtr<T, S, B> where B: Backend {}
 
 pub trait TaggingStrategy<B> {
     type Tag: Copy;


### PR DESCRIPTION
Rewrite the API to be safer and nicer
---
We now requite `StuffingStrategy::Other: Copy`. This small bound makes everything much easier.

Originally, I tried to be flexible and allow it to be `Drop`, which made everything so much more complicated and unsafe.
But this doesn't really make sense, as all `Other` types I could imagine are just basic things like integers which are `Copy`.

This makes a lot of methods safe now, making the documentation example not have any unsafe code (except for its own pointer handling, but not when interacting with `stuff`),